### PR TITLE
fix sagemaker version and add missing packages

### DIFF
--- a/penguins/penguins-cohort.ipynb
+++ b/penguins/penguins-cohort.ipynb
@@ -28,6 +28,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "a2ad1064",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q --upgrade pip\n",
+    "!pip install -q --upgrade awscli boto3\n",
+    "!pip install -q sagemaker==2.173.0\n",
+    "!pip show sagemaker"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 126,
    "id": "212a0538-62b5-4875-a59c-1a4e1a833a07",
    "metadata": {


### PR DESCRIPTION
I had to bump up the sagemaker version to support PipelineDefinitionConfig. This was added after earlier versions of the notebook(penguins-cohort.ipynb). Also other packages were missing that were in earlier versions of penguins-cohort.ipynb.

PipelineDefinitionConfig — https://github.com/aws/sagemaker-python-sdk/blob/219ad245238c94a31e0960a9ede0470a6b075b56/CHANGELOG.md?plain=1#L38

Hope this helps.