### PR TITLE
change comet_ml to comet-ml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ nbdev
 nbclient
 ipykernel
 Flask
-comet_ml
+comet-ml


### PR DESCRIPTION
original package name comet_ml throws an error since this is not the package name as mentioned here in the official docs: https://www.comet.com/docs/v2/api-and-sdk/python-sdk/releases/

Their own make this mistake as well