### PR TITLE
Fixing the issue - code inside else condition was incorrectly written.

### DIFF
--- a/idx-template.nix
+++ b/idx-template.nix
@@ -8,7 +8,8 @@
     cp -rf ${./.} "$out"
     chmod -R +w "$out"
 
-    ${if aws_access_key_id != "" && aws_secret_access_key != "" && aws_region != "" then ''
+    ${
+      ''
       cat << EOF >> "$out"/.idx/aws.nix
       {
         AWS_ACCESS_KEY_ID = "${aws_access_key_id}";
@@ -16,11 +17,7 @@
         AWS_REGION = "${aws_region}";
       }
       EOF
-    '' else ''
-      cat << EOF >> "$out"/.idx/aws.nix
-      {}
-      EOF
-    ''
+      ''
     }
 
     # Remove the template files


### PR DESCRIPTION
# User description
else "echo "{}" >> \"$out\"/.idx/aws.nix"

must be

else ''"echo "{}" >> \"$out\"/.idx/aws.nix"''

-----

However, since aws related parameter names are required to be later entered, removed checks for blank.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Simplifies AWS credentials handling in the <code>idx-template</code> bootstrap process by removing empty parameter checks and ensuring credentials are always written to <code>.idx/aws.nix</code>. Fixes string quoting issues in the template generation code.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>svpino</td><td>Final-updates</td><td>January 24, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @mittaltanuj and the rest of your team on <a href=https://baz.co/changes/svpino/ml.school/23?tool=ast>(Baz)</a>.