### PR TITLE
Fix conversion to DataFrame for dict input in custom inference Model

### DIFF
--- a/pipelines/inference.py
+++ b/pipelines/inference.py
@@ -88,7 +88,7 @@ class Model(mlflow.pyfunc.PythonModel):
     def predict(
         self,
         context: PythonModelContext,  # noqa: ARG002
-        model_input: pd.DataFrame | list | dict,
+        model_input: pd.DataFrame | list[dict[str, Any]] | dict[str, Any] | list[Any],
         params: dict[str, Any] | None = None,
     ) -> list:
         """Handle the request received from the client.

--- a/pipelines/inference.py
+++ b/pipelines/inference.py
@@ -88,7 +88,7 @@ class Model(mlflow.pyfunc.PythonModel):
     def predict(
         self,
         context: PythonModelContext,  # noqa: ARG002
-        model_input,
+        model_input: pd.DataFrame | list | dict,
         params: dict[str, Any] | None = None,
     ) -> list:
         """Handle the request received from the client.
@@ -100,8 +100,11 @@ class Model(mlflow.pyfunc.PythonModel):
         The caller can specify whether we should capture the input request and
         prediction by using the `data_capture` parameter when making a request.
         """
-        if isinstance(model_input, list | dict):
+        if isinstance(model_input, list):
             model_input = pd.DataFrame(model_input)
+
+        if isinstance(model_input, dict):
+            model_input = pd.DataFrame([model_input])
 
         logging.info(
             "Received prediction request with %d %s",

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -136,7 +136,16 @@ def test_predict_return_empty_list_on_invalid_prediction(model, monkeypatch):
     assert result == []
 
 
-def test_predict(model, monkeypatch):
+@pytest.mark.parametrize(
+    "input_data",
+    [
+        pd.DataFrame([{"island": "Torgersen", "culmen_length_mm": 39.1}]),
+        ["Torgersen", 39.1],
+        {"island": "Torgersen", "culmen_length_mm": 39.1},
+        [{"island": "Torgersen", "culmen_length_mm": 39.1}],
+    ],
+)
+def test_predict(model, monkeypatch, input_data):
     mock_process_input = Mock(return_value=np.array([[0.1, 0.2, 0.3]]))
     mock_process_output = Mock(
         return_value=[{"prediction": "Adelie", "confidence": 0.6}],
@@ -145,7 +154,6 @@ def test_predict(model, monkeypatch):
     monkeypatch.setattr(model, "process_input", mock_process_input)
     monkeypatch.setattr(model, "process_output", mock_process_output)
 
-    input_data = [{"island": "Torgersen", "culmen_length_mm": 39.1}]
     result = model.predict(context=None, model_input=input_data)
 
     assert result == [{"prediction": "Adelie", "confidence": 0.6}]

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -140,9 +140,9 @@ def test_predict_return_empty_list_on_invalid_prediction(model, monkeypatch):
     "input_data",
     [
         pd.DataFrame([{"island": "Torgersen", "culmen_length_mm": 39.1}]),
-        ["Torgersen", 39.1],
-        {"island": "Torgersen", "culmen_length_mm": 39.1},
         [{"island": "Torgersen", "culmen_length_mm": 39.1}],
+        {"island": "Torgersen", "culmen_length_mm": 39.1},
+        ["Torgersen", 39.1],
     ],
 )
 def test_predict(model, monkeypatch, input_data):


### PR DESCRIPTION
The `Model.predict()` method supports `pd.DataFrame`, `list` and `dict` inputs. However, there was a tiny mistake in handling `dict` inputs, which need to be converted to list of dicts before they can be used to construct a `pd.DataFrame`.

Happy to provide a unit test for that, but since it is part of the homework to come up with additional unit tests, I haven't done it yet. Please do let me know if you want me to include it in the PR.