### PR TITLE
Hash sum mismatch during build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,9 +2,14 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.12-bullseye as base
 
 RUN touch /etc/apt/sources.list.d/amd64.list
 RUN dpkg --add-architecture amd64
-RUN apt update
 
-RUN apt-get update \
+RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
+    echo "Acquire::http::No-Cache true;" >> /etc/apt/apt.conf.d/99custom && \
+    echo "Acquire::BrokenProxy    true;" >> /etc/apt/apt.conf.d/99custom
+
+RUN apt update
+    
+RUN apt-get update && apt-get upgrade -y \
     && apt-get -y install --no-install-recommends binutils:amd64 libwebkit2gtk-4.0-dev sqlite3
 
 # Install `just`


### PR DESCRIPTION
I ran into a “Hash Sum mismatch” error while opening the project in a Dev Container.
The issue occurred during the image build step, when `apt-get` was installing packages inside the Dockerfile.

[This fix](https://github.com/jenkinsci/docker/issues/543#issuecomment-2568210821 ) mentioned in a comment on [apt-get delivers error "Hash sum missmatch"](https://github.com/jenkinsci/docker/issues/543) worked for me.


Error logs: 
```
E: Failed to fetch http://deb.debian.org/debian/pool/main/l/lvm2/dmsetup_1.02.175-2.1_arm64.deb Hash Sum mismatch
Hashes of expected file:
- SHA256:36c5e76cfff2be3275275d628a253b57313a240877bd1e3869836b43ccbc1bc8
- MD5Sum:44dce88762ddc3d6591186e32b68defb [weak]
- Filesize:85096 [weak]
Hashes of received file:
- SHA256:aa76eaf1a6e9ee9dfad0c879b8e95c3c44ccc9423a3367f00149d55dda99145c
- MD5Sum:377fcf0d6b3cb0711bbf56945b449253 [weak]
- Filesize:85096 [weak]
Last modification reported: Mon, 22 Feb 2021 22:42:22 +0000
E: Unable to fetch some archives, maybe run apt-get update or try with `--fix-missing?
```