### PR TITLE
Fix Evidently reports rendering in tiny window in Metaflow card server

### DIFF
--- a/src/pipelines/monitoring.py
+++ b/src/pipelines/monitoring.py
@@ -108,7 +108,7 @@ class Monitoring(Pipeline):
                 current_data=self.current_dataset,
                 reference_data=self.reference_dataset,
             )
-            self._render_evidently_report(result)
+            self.html = result.get_html_str(as_iframe=False)
         else:
             self._message("No production data.")
 
@@ -152,7 +152,7 @@ class Monitoring(Pipeline):
                 reference_data=self.reference_dataset,
                 current_data=self.current_dataset,
             )
-            self._render_evidently_report(result)
+            self.html = result.get_html_str(as_iframe=False)
         else:
             self._message("No production data.")
 
@@ -185,7 +185,7 @@ class Monitoring(Pipeline):
                 current_data=self.current_dataset,
                 reference_data=self.reference_dataset,
             )
-            self._render_evidently_report(result)
+            self.html = result.get_html_str(as_iframe=False)
         else:
             self._message("No production data.")
 
@@ -200,18 +200,6 @@ class Monitoring(Pipeline):
         """Display a message in the HTML card associated to a step."""
         self.html = message
         self.logger.info(message)
-
-    def _render_evidently_report(self, result):
-        """Render Evidently report correctly inside card."""
-        import tempfile
-        from pathlib import Path
-
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp:
-            tmp_path = Path(tmp.name)
-        result.save_html(str(tmp_path))
-        with tmp_path.open("r", encoding="utf-8") as f:
-            self.html = f.read()
-        tmp_path.unlink()
 
 
 if __name__ == "__main__":

--- a/src/pipelines/monitoring.py
+++ b/src/pipelines/monitoring.py
@@ -108,7 +108,7 @@ class Monitoring(Pipeline):
                 current_data=self.current_dataset,
                 reference_data=self.reference_dataset,
             )
-            self.html = result._repr_html_()
+            self._render_evidently_report(result)
         else:
             self._message("No production data.")
 
@@ -152,7 +152,7 @@ class Monitoring(Pipeline):
                 reference_data=self.reference_dataset,
                 current_data=self.current_dataset,
             )
-            self.html = result._repr_html_()
+            self._render_evidently_report(result)
         else:
             self._message("No production data.")
 
@@ -185,7 +185,7 @@ class Monitoring(Pipeline):
                 current_data=self.current_dataset,
                 reference_data=self.reference_dataset,
             )
-            self.html = result._repr_html_()
+            self._render_evidently_report(result)
         else:
             self._message("No production data.")
 
@@ -200,6 +200,18 @@ class Monitoring(Pipeline):
         """Display a message in the HTML card associated to a step."""
         self.html = message
         self.logger.info(message)
+
+    def _render_evidently_report(self, result):
+        """Render Evidently report correctly inside card."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp:
+            tmp_path = Path(tmp.name)
+        result.save_html(str(tmp_path))
+        with tmp_path.open("r", encoding="utf-8") as f:
+            self.html = f.read()
+        tmp_path.unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Evidently reports were previously rendered using `result._repr_html_()`, which returns an HTML fragment intended for notebook environments. When displayed inside a Metaflow HTML card, the report appeared in a very small scrollable window.

This change switches to using result.save_html() to generate a full standalone HTML report. The report is written to a temporary file, read into self.html, and then the file is removed. This allows the Metaflow card to render the report correctly at full size.

Helper function `_render_evidently_report()` was created to handle that logic and to avoid repetition across steps.