### PR TITLE
Add unit tests covering inference model edge cases

### DIFF
--- a/tests/inference/test_model_artifacts.py
+++ b/tests/inference/test_model_artifacts.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -60,3 +60,14 @@ def test_keras_backend_is_unchanged_if_present(model, context, monkeypatch):
     monkeypatch.setenv("KERAS_BACKEND", "jax")
     model.load_context(context)
     assert os.getenv("KERAS_BACKEND") == "jax"
+
+
+def test_load_artifacts_skipped_when_context_is_none(model):
+    # Backend initialization is patched out so the early return is the only thing
+    # under test and we don't touch the real backend.
+    with patch("importlib.import_module"):
+        model.load_context(context=None)
+
+    assert not hasattr(model, "model")
+    assert not hasattr(model, "features_transformer")
+    assert not hasattr(model, "target_transformer")

--- a/tests/inference/test_model_backend.py
+++ b/tests/inference/test_model_backend.py
@@ -123,6 +123,18 @@ class TestModelBackend:
             model.load_context(context=None)
             assert model.backend is None
 
+    def test_backend_defaults_to_local_when_env_unset(self, monkeypatch):
+        """An unset MODEL_BACKEND should default to the Local backend."""
+        from inference.backend import Local
+
+        monkeypatch.delenv("MODEL_BACKEND", raising=False)
+        monkeypatch.delenv("MODEL_BACKEND_CONFIG", raising=False)
+
+        model = Model()
+        model.load_context(context=None)
+
+        assert isinstance(model.backend, Local)
+
 
 @pytest.fixture
 def backend():

--- a/tests/inference/test_model_predict.py
+++ b/tests/inference/test_model_predict.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
+import pytest
 
 
 def test_predict_returns_empty_list_if_input_is_empty(model):
@@ -128,3 +129,33 @@ def test_process_output_returns_species(model):
 
 def test_process_output_returns_empty_list_if_it_receives_none(model):
     assert model.process_output(None) == []
+
+
+def test_process_output_returns_max_probability_as_confidence(model):
+    output = np.array([[0.7, 0.2, 0.1]])
+    result = model.process_output(output)
+
+    assert result[0]["confidence"] == pytest.approx(0.7)
+
+
+def test_process_output_confidence_matches_predicted_class(model):
+    output = np.array([[0.7, 0.2, 0.1], [0.1, 0.1, 0.8]])
+    result = model.process_output(output)
+
+    assert [r["prediction"] for r in result] == ["Adelie", "Gentoo"]
+    assert [r["confidence"] for r in result] == pytest.approx([0.7, 0.8])
+
+
+def test_process_output_returns_native_python_types(model):
+    output = np.array([[0.6, 0.3, 0.1]])
+    result = model.process_output(output)
+
+    assert type(result[0]["prediction"]) is str
+    assert type(result[0]["confidence"]) is float
+
+
+def test_predict_does_not_call_backend_when_backend_is_none(model):
+    model.backend = None
+    result = model.predict(None, [{"island": "Torgersen"}])
+
+    assert result == [{"prediction": "Adelie", "confidence": pytest.approx(0.6)}]

--- a/tests/inference/test_model_schema.py
+++ b/tests/inference/test_model_schema.py
@@ -1,0 +1,69 @@
+import pydantic
+import pytest
+
+from inference.model import Input, Output
+
+
+class TestInputSchema:
+    """Tests for the Input prediction schema."""
+
+    def test_input_defaults_are_all_none(self):
+        """Every field should default to None so the schema stays fully optional."""
+        assert Input().model_dump() == {
+            "island": None,
+            "culmen_length_mm": None,
+            "culmen_depth_mm": None,
+            "flipper_length_mm": None,
+            "body_mass_g": None,
+            "sex": None,
+        }
+
+    def test_input_accepts_full_payload(self):
+        """A fully populated payload should expose exactly the expected fields."""
+        sample = Input(
+            island="Torgersen",
+            culmen_length_mm=39.1,
+            culmen_depth_mm=18.7,
+            flipper_length_mm=181.0,
+            body_mass_g=3750.0,
+            sex="MALE",
+        )
+
+        assert sample.model_dump().keys() == {
+            "island",
+            "culmen_length_mm",
+            "culmen_depth_mm",
+            "flipper_length_mm",
+            "body_mass_g",
+            "sex",
+        }
+
+    def test_input_coerces_numeric_strings_to_float(self):
+        """Numeric strings should be coerced to float to keep DataFrame dtypes sane."""
+        sample = Input(culmen_length_mm="39.1")
+
+        assert sample.culmen_length_mm == pytest.approx(39.1)
+        assert isinstance(sample.culmen_length_mm, float)
+
+    def test_input_rejects_non_numeric_for_float_field(self):
+        """A non-numeric value for a float field should raise a validation error."""
+        with pytest.raises(pydantic.ValidationError):
+            Input(body_mass_g="heavy")
+
+
+class TestOutputSchema:
+    """Tests for the Output prediction schema."""
+
+    def test_output_defaults_are_none(self):
+        """Both fields should default to None."""
+        output = Output()
+
+        assert output.prediction is None
+        assert output.confidence is None
+
+    def test_output_accepts_values(self):
+        """A populated output should round-trip its values."""
+        output = Output(prediction="Adelie", confidence=0.6)
+
+        assert output.prediction == "Adelie"
+        assert output.confidence == pytest.approx(0.6)


### PR DESCRIPTION
## Summary

Adds unit tests that lock in behavior for several inference model edge cases so regressions in the serving path surface in CI:

- **`load_context` early return** when `context` is `None` (no artifacts loaded).
- **Backend default** to `Local` when `MODEL_BACKEND`/`MODEL_BACKEND_CONFIG` are unset.
- **`process_output`** confidence handling — max probability as confidence, confidence matches the predicted class, and native Python return types.
- **`predict`** returns the processed output without invoking the backend when `backend` is `None`.
- New **`test_model_schema.py`** covering the model schema.

## Test plan

- `just test` / `uv run pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)